### PR TITLE
make files contain html5 doctype

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -279,7 +279,7 @@ async function begin(){
 
 		const manifestLinkElement = html.window.document.createElement("link"); manifestLinkElement.rel = "manifest"; manifestLinkElement.href = relativeManifestLink;
 		html.window.document.head.appendChild(manifestLinkElement);
-		await fs.writeFile(markupPath, html.window.document.documentElement.outerHTML);
+		await fs.writeFile(markupPath, html.serialize());
 
 	}
 

--- a/src/icons.js
+++ b/src/icons.js
@@ -180,7 +180,7 @@ async function add(){
 
 			iconsContainer.remove();
 		
-			await fs.writeFile(markupPath, html.window.document.documentElement.outerHTML);
+			await fs.writeFile(markupPath, html.serialize());
 
 		}
 

--- a/src/serviceworker.js
+++ b/src/serviceworker.js
@@ -53,7 +53,7 @@ async function link(){
 			const bridge = html.window.document.createElement("script"); bridge.src = `${ewabConfig.alias}/serviceworker-bridge.js`; bridge.type = "module";
 			html.window.document.head.appendChild(bridge);
 		
-			await fs.writeFile(markupPath, html.window.document.documentElement.outerHTML);
+			await fs.writeFile(markupPath, html.serialize());
 
 		}
 


### PR DESCRIPTION
replaced outerHTML en jsDOM with serialize() as outerHTML strips the <!DOCTYPE>.